### PR TITLE
Add `object-tools` block to change form

### DIFF
--- a/tabbed_admin/templates/tabbed_admin/change_form.html
+++ b/tabbed_admin/templates/tabbed_admin/change_form.html
@@ -2,7 +2,7 @@
 {% load i18n admin_modify admin_urls tabbed_admin_tags %}
 
 {% block content %}
-XS
+
 <div id="content-main">
   {% block object-tools %}{{ block.super }}{% endblock %}
     <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}

--- a/tabbed_admin/templates/tabbed_admin/change_form.html
+++ b/tabbed_admin/templates/tabbed_admin/change_form.html
@@ -2,7 +2,9 @@
 {% load i18n admin_modify admin_urls tabbed_admin_tags %}
 
 {% block content %}
+XS
 <div id="content-main">
+  {% block object-tools %}{{ block.super }}{% endblock %}
     <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
         <div>
             {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
@@ -67,14 +69,14 @@
                             $('#tabs #for_' +  this.id).addClass("errortab");
                         }
                     });
-                    
+
                     $("#tabs").on('tabsactivate', function(event, ui) {
                         var scrollPos = $(window).scrollTop();
                         var hash = ui.newTab.children("li a").attr("href");
                         window.location.hash = hash;
                         $(window).scrollTop(scrollPos);
                     });
-                    
+
                     if ($('.errornote').length) {
                         $('.errornote').addClass('tabbed-errornote');
                     }
@@ -100,4 +102,3 @@
     </form>
 </div>
 {% endblock %}
-


### PR DESCRIPTION
Seems this block was missing, causing the `history` and `view on site` link to be missing. The changes here adds the block calling `{{ block.super }}`