### PR TITLE
Adjusted Tab Selection for jQueryUI 1.10+

### DIFF
--- a/tabbed_admin/templates/tabbed_admin/change_form.html
+++ b/tabbed_admin/templates/tabbed_admin/change_form.html
@@ -60,7 +60,7 @@
                     }
                     // enable the first non-disabled tab in add view
                     {% if add %}
-                        $('#tabs').tabs("select", enabled_tabs[0]);
+                        $('#tabs').tabs("option", "active", enabled_tabs[0]);
                     {% endif %}
 
                     // Hightlight tabs with errors inside


### PR DESCRIPTION
In jQueryUI v1.9, the `select` method was [deprecated](http://jqueryui.com/upgrade-guide/1.9/#deprecated-select-method):

>The select method has been deprecated in favor of just updating the active option. You should replace all calls to the select method with calls to the option method to change the active option.

In v1.10, it was [removed entirely](http://bugs.jqueryui.com/ticket/7156).

As jQueryUI 1.11.4 is bundled with **django-tabbed-admin**, a `no such method 'select' for tabs widget instance` exception is thrown when trying to select the first non-disabled tab in add view.

This PR updates `change_form.html` to use the new jQueryUI method for selecting tabs via `option`, namely:
> $('#tabs').tabs("**option**", "**active**", enabled_tabs[0]);


