### PR TITLE
Better import of jQuery for the change_form that adds the jQuery.ui.t…

### DIFF
--- a/tabbed_admin/templates/tabbed_admin/change_form.html
+++ b/tabbed_admin/templates/tabbed_admin/change_form.html
@@ -82,7 +82,9 @@
                     }
 
 
-                })(django.jQuery);
+                })((typeof window.jQuery == 'undefined' && typeof window.django != 'undefined') 
+                ? django.jQuery 
+                : jQuery);
             </script>
             <!-- end admin_tabs stuff -->
 


### PR DESCRIPTION
See issue [35](https://github.com/omji/django-tabbed-admin/issues/35):

The error "Uncaught TypeError: $(...).tabs is not a function" is produced when using django-tabbed-admin under the following setup:

Django = 1.10.5
django-tabbed-admin=1.0.4
DEFAULT_JQUERY_UI_JS = 'tabbed_admin/js/jquery-ui-1.11.4.min.js'
The problem is that the code in jquery-ui-1.11.4.min.js is as follows:

```javascript
/*! jQuery UI - v1.11.4 - 2015-07-27
(...)*/
jQuery = jQuery \|\| django.jQuery.noConflict(false); 
```

and the code on django-tabbed-admin uses it this way (change_form.html):
```javascript
    <script type="text/javascript">
        (function($) {
            $(window).scrollTop()
            $('#tabs').tabs({
                {% if add %}
                // when adding, don't select a tab by default, we'll do it ourselves
                // by finding the first available tab.
                selected: -1
                {% endif %}
            });
        (....)
        })(django.jQuery);
    </script>
    <!-- end admin_tabs stuff -->
```

To sort this out this should be what would be passed in to the IIFE instead of the (django.jQuery) as above:

```javascript
    <script type="text/javascript">
        (function($) {
            (....)
        })((typeof window.jQuery == 'undefined' && typeof window.django != 'undefined')
  ? django.jQuery
  : jQuery)
    </script>
    <!-- end admin_tabs stuff -->
```