### PR TITLE
Fix for Django 3> (ugettext* and ungettext functions now lose the u)

### DIFF
--- a/tabbed_admin/admin.py
+++ b/tabbed_admin/admin.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.admin.options import ModelAdmin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .settings import USE_JQUERY_UI, JQUERY_UI_CSS, JQUERY_UI_JS
 


### PR DESCRIPTION
Fix #43